### PR TITLE
Removes createDatabases option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ $ kivik validate path/to/json/document.json path/to/json/schema.json
 - `server`: Base URL of the server. The default is `http://localhost:5984/`. You can specify HTTP authentication in the URL; see the example above.
 - `db`: Specify a particular database to deploy. You can use this option multiple times.
 - `fixtures`: Insert fixtures located in target directory.
-- `create-databases`: Create databases found in the target directory on the server.
 - `quiet`: Suppress console.log output.
 
 ## Expected directory structure

--- a/src/Database.js
+++ b/src/Database.js
@@ -3,7 +3,7 @@ const globby = require("globby");
 const path = require("path");
 const DesignDoc = require("./DesignDoc");
 
-const keys = ["deployFixtures", "createDatabases", "excludeDesign", "verbose"];
+const keys = ["deployFixtures", "excludeDesign", "verbose"];
 const withDefaults = require("./options").withDefaults(keys);
 
 module.exports = function Database(directory, options = {}, validator = null) {
@@ -141,20 +141,10 @@ module.exports = function Database(directory, options = {}, validator = null) {
     }
 
     if (!dbExists) {
-      if (options.createDatabases) {
-        if (options.verbose > 0) {
-          console.log(
-            `Database ${name} does not exist. Will attempt to create it.`
-          );
-        }
-        try {
-          await nanoInstance.db.create(name);
-        } catch (e) {
-          console.error(`Could not create database ${name}: ${e.message}`);
-        }
-      } else {
-        console.error(`Database ${name} does not exist.`);
-        return;
+      try {
+        await nanoInstance.db.create(name);
+      } catch (e) {
+        console.error(`Could not create database ${name}: ${e.message}`);
       }
     }
 

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -11,7 +11,6 @@ module.exports = function KivikInstance(options = {}) {
 
   options.context = "inspect";
   options.deployFixtures = true;
-  options.createDatabases = true;
 
   this.kivik = new Kivik(options);
 

--- a/src/Kivik.js
+++ b/src/Kivik.js
@@ -13,7 +13,6 @@ const keys = [
   "context",
   // these three are passed to Database
   "deployFixtures",
-  "createDatabases",
   "excludeDesign",
   "verbose",
 ];

--- a/src/cli/deploy.js
+++ b/src/cli/deploy.js
@@ -1,14 +1,7 @@
 const authedNano = require("../nano");
 const Kivik = require("../Kivik");
 
-const keys = [
-  "url",
-  "user",
-  "password",
-  "deployFixtures",
-  "createDatabases",
-  "suffix",
-];
+const keys = ["url", "user", "password", "deployFixtures", "suffix"];
 const options = require("../options").slice(keys);
 
 module.exports = {

--- a/src/options.js
+++ b/src/options.js
@@ -9,11 +9,6 @@ const options = {
     default: "inspect",
     hidden: true,
   },
-  createDatabases: {
-    type: "boolean",
-    default: true,
-    describe: "Creates databases at the CouchDB endpoint if they do not exist.",
-  },
   deployFixtures: {
     type: "boolean",
     default: false,


### PR DESCRIPTION
Kivik will always attempt to create a database when deploying if it doesn't already exist.

Closes #30.