### PR TITLE
Container accepts user/password config

### DIFF
--- a/src/cli/inspect.js
+++ b/src/cli/inspect.js
@@ -12,7 +12,11 @@ module.exports = {
       argv.verbose = 1;
       argv.v = 1;
     }
-    const instance = new Instance(argv.directory, argv);
+    const instance = await Instance.get(argv.directory, argv.port, argv);
     await instance.start();
+
+    process.on("SIGINT", () => {
+      instance.stop();
+    });
   },
 };

--- a/src/container.ini
+++ b/src/container.ini
@@ -1,5 +1,0 @@
-[admins]
-kivikadmin = kivikpassword
-
-[couchdb]
-single_node = true

--- a/test/Container.js
+++ b/test/Container.js
@@ -1,24 +1,36 @@
-require("chai").should();
+const chai = require("chai");
+chai.use(require("chai-as-promised"));
+chai.should();
+
 const getPort = require("get-port");
 const authedNano = require("../src/util").authedNano;
 
 const Container = require("../src/Container");
+const user = "kivikadmin";
+const password = "kivikadmin";
 
 describe("Container", function () {
   this.timeout(0);
+  let container;
 
   it("should create a reachable Docker container", async () => {
     const port = await getPort();
-    const container = new Container(port);
+    container = await Container.get(port, { user, password });
 
     await container.start();
 
-    const nano = authedNano(port, "kivikadmin", "kivikpassword");
-    const dbs = await nano.db.list();
+    const nano = authedNano(port, user, password);
+    nano.db.list().should.eventually.have.length(3);
 
     await container.stop();
 
-    dbs.should.include("_users");
-    dbs.should.include("_replicator");
+    nano.db.list().should.eventually.throw();
+  });
+
+  after(async () => {
+    try {
+      await container.dockerInterface.stop();
+      await container.dockerInterface.remove();
+    } catch (_) {}
   });
 });

--- a/test/Instance.js
+++ b/test/Instance.js
@@ -7,11 +7,12 @@ const directory = "example";
 describe("Instance", function () {
   this.timeout(0);
 
-  const instance = new Instance(directory);
-  let nano;
+  let instance;
 
   before(async () => {
-    nano = await instance.start();
+    instance = await Instance.get(directory);
+    await instance.start();
+    await instance.deploy();
   });
 
   it("should create and load a Kivik instance", async () => {
@@ -20,7 +21,7 @@ describe("Instance", function () {
   });
 
   it("should create and start a reachable Container", async () => {
-    const db = await nano.db.get("testdb");
+    const db = await instance.nano.db.get("testdb");
     db.should.haveOwnProperty("db_name", "testdb");
   });
 

--- a/test/Kivik.js
+++ b/test/Kivik.js
@@ -15,7 +15,7 @@ describe("Kivik", function () {
 
   before(async () => {
     kivik = await Kivik.fromDirectory(directory);
-    container = new Container(await getPort());
+    container = await Container.get(await getPort());
     nano = await container.start();
     testdb = nano.use("testdb");
   });


### PR DESCRIPTION
* Refactors Container/Instance in the style of Kivik etc.
* Supports user/password options in Container, which closes #33
* Dispenses of the .ini file in lieu of environment variables and manual Couch db creation
* Moves SIGINT trigger into the inspect handler. Some more work is required here on actually testing these handlers